### PR TITLE
default view template shouldn't fail when assignee is nil

### DIFF
--- a/jira/cli/templates.go
+++ b/jira/cli/templates.go
@@ -26,7 +26,7 @@ summary: {{ .fields.summary }}
 project: {{ .fields.project.key }}
 components: {{ range .fields.components }}{{ .name }} {{end}}
 issuetype: {{ .fields.issuetype.name }}
-assignee: {{ .fields.assignee.name }}
+assignee: {{ if .fields.assignee }}{{ .fields.assignee }}{{end}}
 reporter: {{ .fields.reporter.name }}
 watchers: {{ range .fields.customfield_10110 }}{{ .name }} {{end}}
 blockers: {{ range .fields.issuelinks }}{{if .outwardIssue}}{{ .outwardIssue.key }}[{{.outwardIssue.fields.status.name}}]{{end}}{{end}}


### PR DESCRIPTION
The default view template was failing with this error whenever I tried to
view a jira that had no assignee:
assignee: 2015-02-16T08:31:58.564-08:00 ERROR [util.go:109] Failed to execute template: template: template:7:20: executing "template" at <.fields.assignee.nam...>: nil pointer evaluating interface {}.name