### PR TITLE
fix "take" command not honouring user option

### DIFF
--- a/jira/main.go
+++ b/jira/main.go
@@ -267,7 +267,7 @@ Command Options:
 		setEditing(true)
 		err = c.CmdComment(args["ISSUE"].(string))
 	} else if validCommand("take") {
-		err = c.CmdAssign(args["ISSUE"].(string), user)
+		err = c.CmdAssign(args["ISSUE"].(string), opts["user"])
 	} else if validCommand("browse") || validCommand("b") {
 		opts["browse"] = "true"
 		err = c.Browse(args["ISSUE"].(string))


### PR DESCRIPTION
"take" was simply a partial on "assign", but accidentally used the value
of $USER from the environment rather than `opts["user"]`, preventing the
user from overriding this value in config.yml or as a command-line
argument.