### PR TITLE
Add 'updated' to queryfields; dateFormat template command; bug fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ General Options:
 Query Options:
   -a --assignee=USER        Username assigned the issue
   -c --component=COMPONENT  Component to Search for
-  -f --queryfields=FIELDS   Fields that are used in "list" template: (default: summary,created,priority,status,reporter,assignee)
+  -f --queryfields=FIELDS   Fields that are used in "list" template: (default: summary,created,updated,priority,status,reporter,assignee)
   -i --issuetype=ISSUETYPE  The Issue Type
   -l --limit=VAL            Maximum number of results to return in query (default: 500)
   -p --project=PROJECT      Project to Search for

--- a/jira/cli/util.go
+++ b/jira/cli/util.go
@@ -100,6 +100,14 @@ func fuzzyAge(start string) (string, error) {
 	return "unknown", nil
 }
 
+func dateFormat(format string, content string) (string, error) {
+	if t, err := time.Parse("2006-01-02T15:04:05.000-0700", content); err != nil {
+		return "", err
+	} else {
+		return t.Format(format), nil
+	}
+}
+
 func runTemplate(templateContent string, data interface{}, out io.Writer) error {
 
 	if out == nil {
@@ -170,6 +178,9 @@ func runTemplate(templateContent string, data interface{}, out io.Writer) error 
 		},
 		"age": func(content string) (string, error) {
 			return fuzzyAge(content)
+		},
+		"dateFormat": func(format string, content string) (string, error) {
+			return dateFormat(format, content)
 		},
 	}
 	if tmpl, err := template.New("template").Funcs(funcs).Parse(templateContent); err != nil {

--- a/jira/main.go
+++ b/jira/main.go
@@ -352,7 +352,7 @@ Command Options:
 	case "browse":
 		opts["browse"] = true
 		err = c.Browse(args[0])
-	case "export-tempaltes":
+	case "export-templates":
 		err = c.CmdExportTemplates()
 	case "assign":
 		err = c.CmdAssign(args[0], args[1])

--- a/jira/main.go
+++ b/jira/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	user := os.Getenv("USER")
 	home := os.Getenv("HOME")
-	defaultQueryFields := "summary,created,priority,status,reporter,assignee"
+	defaultQueryFields := "summary,created,updated,priority,status,reporter,assignee"
 	defaultSort := "priority asc, created"
 	defaultMaxResults := 500
 


### PR DESCRIPTION
I've included the 'updated' field into the default query fields, as it seemed like an oversight, and I need it :)

In the process, noticed that export-templates was broken due to a typo, so fixed that.

I've added a dateFormat template helper, so I can get the create/update time in a more report friendly form.

