### PR TITLE
Add 'labels' command to set/add/remove labels

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -542,7 +542,7 @@ func (c *Cli) CmdComment(issue string) error {
 	return nil
 }
 
-func (c *Cli) CmdLabels(issue string, command string, labels []string) error {
+func (c *Cli) CmdLabels(command string, issue string, labels []string) error {
 	log.Debug("label called")
 
 	if command != "add" && command != "remove" && command != "set" {

--- a/commands.go
+++ b/commands.go
@@ -542,11 +542,11 @@ func (c *Cli) CmdComment(issue string) error {
 	return nil
 }
 
-func (c *Cli) CmdLabels(command string, issue string, labels []string) error {
+func (c *Cli) CmdLabels(action string, issue string, labels []string) error {
 	log.Debug("label called")
 
-	if command != "add" && command != "remove" && command != "set" {
-		return fmt.Errorf("command must be 'add', 'set' or 'remove': %q is invalid", command)
+	if action != "add" && action != "remove" && action != "set" {
+		return fmt.Errorf("action must be 'add', 'set' or 'remove': %q is invalid", action)
 	}
 
 	handlePut := func(json string) error {
@@ -579,24 +579,24 @@ func (c *Cli) CmdLabels(command string, issue string, labels []string) error {
 
 	var labels_json string
 	var err error
-	if command == "set" {
-		labelsCommands := make([]map[string][]string, 1)
-		labelsCommands[0] = map[string][]string{
+	if action == "set" {
+		labelsActions := make([]map[string][]string, 1)
+		labelsActions[0] = map[string][]string{
 			"set": labels,
 		}
 		labels_json, err = jsonEncode(map[string]interface{}{
-			"labels": labelsCommands,
+			"labels": labelsActions,
 		})
 	} else {
-		labelsCommands := make([]map[string]string, len(labels))
+		labelsActions := make([]map[string]string, len(labels))
 		for i, label := range labels {
-			labelCommandMap := map[string]string{
-				command: label,
+			labelActionMap := map[string]string{
+				action: label,
 			}
-			labelsCommands[i] = labelCommandMap
+			labelsActions[i] = labelActionMap
 		}
 		labels_json, err = jsonEncode(map[string]interface{}{
-			"labels": labelsCommands,
+			"labels": labelsActions,
 		})
 	}
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -65,7 +65,7 @@ Usage:
   jira start ISSUE [--edit] <Edit Options>
   jira stop ISSUE [--edit] <Edit Options>
   jira comment ISSUE [--noedit] <Edit Options>
-  jira labels ISSUE set,add,remove [LABEL] ...
+  jira (set,add,remove) labels ISSUE [LABEL] ...
   jira take ISSUE
   jira (assign|give) ISSUE ASSIGNEE
   jira fields
@@ -219,6 +219,7 @@ Command Options:
 			args = args[1:]
 		} else if len(args) > 1 {
 			// look at second arg for "dups" and "blocks" commands
+			// also for 'set/add/remove' actions like 'labels'
 			if alias, ok := jiraCommands[args[1]]; ok {
 				command = alias
 				args = append(args[:1], args[2:]...)
@@ -382,7 +383,10 @@ Command Options:
 		err = c.CmdComment(args[0])
 	case "labels":
 		requireArgs(2)
-		err = c.CmdLabels(args[0], args[1], args[2:])
+		action := args[0]
+		issue := args[1]
+		labels := args[2:]
+		err = c.CmdLabels(action, issue, labels)
 	case "take":
 		requireArgs(1)
 		err = c.CmdAssign(args[0], opts["user"].(string))

--- a/main/main.go
+++ b/main/main.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	log          = logging.MustGetLogger("jira")
-	format       = "%{color}%{time:2006-01-02T15:04:05.000Z07:00} %{level:-5s} [%{shortfile}]%{color:reset} %{message}"
+	log    = logging.MustGetLogger("jira")
+	format = "%{color}%{time:2006-01-02T15:04:05.000Z07:00} %{level:-5s} [%{shortfile}]%{color:reset} %{message}"
 )
 
 func main() {
@@ -65,6 +65,7 @@ Usage:
   jira start ISSUE [--edit] <Edit Options>
   jira stop ISSUE [--edit] <Edit Options>
   jira comment ISSUE [--noedit] <Edit Options>
+  jira labels ISSUE set,add,remove [LABEL] ...
   jira take ISSUE
   jira (assign|give) ISSUE ASSIGNEE
   jira fields
@@ -136,6 +137,8 @@ Command Options:
 		"start":            "start",
 		"stop":             "stop",
 		"comment":          "comment",
+		"label":            "labels",
+		"labels":           "labels",
 		"take":             "take",
 		"assign":           "assign",
 		"give":             "assign",
@@ -377,6 +380,9 @@ Command Options:
 		requireArgs(1)
 		setEditing(true)
 		err = c.CmdComment(args[0])
+	case "labels":
+		requireArgs(2)
+		err = c.CmdLabels(args[0], args[1], args[2:])
 	case "take":
 		requireArgs(1)
 		err = c.CmdAssign(args[0], opts["user"].(string))


### PR DESCRIPTION
This adds 'labels' command, which allows for the setting, addition and removal
of labels on an issue.

'set' action resets the issue labels to the list provided.
'add' action adds the supplied labels to the issue
'remove' action removes the supplied labels from the issue

The API already gracefully handles duplication, removal of non-existant labels, and the
supplying of an empty list of labels (which is useful in the case of 'set')

Eg

jira labels TEST-123 add label1 label2 label3
jira labels TEST-123 remove label1 label2
jira labels TEST-123 set label1 label2 label3
jira labels TEST-123 set # clears any labels on the issue
jira labels TEST-123 add # no-op
jira labels TEST-123 remove # no-op

This mirrors the functionality of the API.