### PR TITLE
Expose key functionality for library consumption

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -177,6 +177,10 @@ func (c *Cli) makeRequest(req *http.Request) (resp *http.Response, err error) {
 	return resp, nil
 }
 
+func (c *Cli) GetTemplate(name string) string {
+	return c.getTemplate(name)
+}
+
 func (c *Cli) getTemplate(name string) string {
 	if override, ok := c.opts["template"].(string); ok {
 		if _, err := os.Stat(override); err == nil {

--- a/cli.go
+++ b/cli.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger("jira")
+	log     = logging.MustGetLogger("jira")
 	VERSION string
 )
 

--- a/cli.go
+++ b/cli.go
@@ -368,6 +368,16 @@ func (c *Cli) SaveData(data interface{}) error {
 	return nil
 }
 
+func (c *Cli) ViewIssue(issue string) (interface{}, error) {
+	uri := fmt.Sprintf("%s/rest/api/2/issue/%s", c.endpoint, issue)
+	data, err := responseToJson(c.get(uri))
+	if err != nil {
+		return nil, err
+	} else {
+		return data, nil
+	}
+}
+
 func (c *Cli) FindIssues() (interface{}, error) {
 	var query string
 	var ok bool

--- a/commands.go
+++ b/commands.go
@@ -80,12 +80,10 @@ func (c *Cli) CmdList() error {
 func (c *Cli) CmdView(issue string) error {
 	log.Debug("view called")
 	c.Browse(issue)
-	uri := fmt.Sprintf("%s/rest/api/2/issue/%s", c.endpoint, issue)
-	data, err := responseToJson(c.get(uri))
+	data, err := c.ViewIssue(issue)
 	if err != nil {
 		return err
 	}
-
 	return runTemplate(c.getTemplate("view"), data, nil)
 }
 

--- a/main/main.go
+++ b/main/main.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	log          = logging.MustGetLogger("jira")
-	format       = "%{color}%{time:2006-01-02T15:04:05.000Z07:00} %{level:-5s} [%{shortfile}]%{color:reset} %{message}"
+	log    = logging.MustGetLogger("jira")
+	format = "%{color}%{time:2006-01-02T15:04:05.000Z07:00} %{level:-5s} [%{shortfile}]%{color:reset} %{message}"
 )
 
 func main() {

--- a/util.go
+++ b/util.go
@@ -109,8 +109,11 @@ func dateFormat(format string, content string) (string, error) {
 	}
 }
 
-func runTemplate(templateContent string, data interface{}, out io.Writer) error {
+func RunTemplate(templateContent string, data interface{}, out io.Writer) error {
+	return runTemplate(templateContent, data, out)
+}
 
+func runTemplate(templateContent string, data interface{}, out io.Writer) error {
 	if out == nil {
 		out = os.Stdout
 	}


### PR DESCRIPTION
I've added exposed versions of runTemplate and getTemplate, so I can access the template engine with my own Buffer. I opted to add tandem RunTemplate and GetTemplate, rather than a search-replace fix, to make the smallest change possible. Happy to rework if you're not fussed about changing the internal API.

I've split the API-integrated part of `CmdView` into `ViewIssue(...)` as per `FindIssues(...)`.

These are the only exposures I need right now, let me know if you'd like anything else included.