### PR TITLE
Support for removing a given watcher

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -474,12 +474,20 @@ func (c *Cli) FindIssues() (interface{}, error) {
 	}
 }
 
+func (c *Cli) GetOptString(optName string, dflt string) string {
+	return c.getOptString(optName, dflt)
+}
+
 func (c *Cli) getOptString(optName string, dflt string) string {
 	if val, ok := c.opts[optName].(string); ok {
 		return val
 	} else {
 		return dflt
 	}
+}
+
+func (c *Cli) GetOptBool(optName string, dflt bool) bool {
+	return c.getOptBool(optName, dflt)
 }
 
 func (c *Cli) getOptBool(optName string, dflt bool) bool {

--- a/cli.go
+++ b/cli.go
@@ -106,6 +106,24 @@ func (c *Cli) put(uri string, content string) (*http.Response, error) {
 	return c.makeRequestWithContent("PUT", uri, content)
 }
 
+func (c *Cli) delete(uri string) (*http.Response, error) {
+	method := "DELETE"
+	req, _ := http.NewRequest(method, uri, nil)
+	log.Info("%s %s", req.Method, req.URL.String())
+	if resp, err := c.makeRequest(req); err != nil {
+		return nil, err
+	} else {
+		if resp.StatusCode == 401 {
+			if err := c.CmdLogin(); err != nil {
+				return nil, err
+			}
+			req, _ = http.NewRequest(method, uri, nil)
+			return c.makeRequest(req)
+		}
+		return resp, err
+	}
+}
+
 func (c *Cli) makeRequestWithContent(method string, uri string, content string) (*http.Response, error) {
 	buffer := bytes.NewBufferString(content)
 	req, _ := http.NewRequest(method, uri, buffer)

--- a/commands.go
+++ b/commands.go
@@ -414,6 +414,62 @@ func (c *Cli) CmdWatch(issue string) error {
 	return nil
 }
 
+func (c *Cli) CmdVote(issue string) error {
+	log.Debug("vote called")
+
+	uri := fmt.Sprintf("%s/rest/api/2/issue/%s/votes", c.endpoint, issue)
+	if c.getOptBool("dryrun", false) {
+		log.Debug("POST: %s", "")
+		log.Debug("Dryrun mode, skipping POST")
+		return nil
+	}
+	resp, err := c.post(uri, "")
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == 204 {
+		c.Browse(issue)
+		if !c.opts["quiet"].(bool) {
+			fmt.Printf("OK %s %s/browse/%s\n", issue, c.endpoint, issue)
+		}
+	} else {
+		logBuffer := bytes.NewBuffer(make([]byte, 0))
+		resp.Write(logBuffer)
+		err := fmt.Errorf("Unexpected Response From POST")
+		log.Error("%s:\n%s", err, logBuffer)
+		return err
+	}
+	return nil
+}
+
+func (c *Cli) CmdUnvote(issue string) error {
+	log.Debug("unvote called")
+
+	uri := fmt.Sprintf("%s/rest/api/2/issue/%s/votes", c.endpoint, issue)
+	if c.getOptBool("dryrun", false) {
+		log.Debug("DELETE: %s", "")
+		log.Debug("Dryrun mode, skipping DELETE")
+		return nil
+	}
+	resp, err := c.delete(uri)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == 204 {
+		c.Browse(issue)
+		if !c.opts["quiet"].(bool) {
+			fmt.Printf("OK %s %s/browse/%s\n", issue, c.endpoint, issue)
+		}
+	} else {
+		logBuffer := bytes.NewBuffer(make([]byte, 0))
+		resp.Write(logBuffer)
+		err := fmt.Errorf("Unexpected Response From DELETE")
+		log.Error("%s:\n%s", err, logBuffer)
+		return err
+	}
+	return nil
+}
+
 func (c *Cli) CmdTransition(issue string, trans string) error {
 	log.Debug("transition called")
 	uri := fmt.Sprintf("%s/rest/api/2/issue/%s/transitions?expand=transitions.fields", c.endpoint, issue)

--- a/commands.go
+++ b/commands.go
@@ -385,22 +385,34 @@ func (c *Cli) CmdDups(duplicate string, issue string) error {
 	return nil
 }
 
-func (c *Cli) CmdWatch(issue string) error {
-	watcher := c.getOptString("watcher", c.opts["user"].(string))
-	log.Debug("watch called")
+func (c *Cli) CmdWatch(issue string, watcher string, remove bool) error {
+	log.Debug("watch called: watcher: %q, remove: %n", watcher, remove)
 
+	var uri string
 	json, err := jsonEncode(watcher)
 	if err != nil {
 		return err
 	}
 
-	uri := fmt.Sprintf("%s/rest/api/2/issue/%s/watchers", c.endpoint, issue)
 	if c.getOptBool("dryrun", false) {
-		log.Debug("POST: %s", json)
-		log.Debug("Dryrun mode, skipping POST")
+		if !remove {
+			log.Debug("POST: %s", json)
+			log.Debug("Dryrun mode, skipping POST")
+		} else {
+			log.Debug("DELETE: %s", watcher)
+			log.Debug("Dryrun mode, skipping POST")
+		}
 		return nil
 	}
-	resp, err := c.post(uri, json)
+
+	var resp *http.Response
+	if !remove {
+		uri = fmt.Sprintf("%s/rest/api/2/issue/%s/watchers", c.endpoint, issue)
+		resp, err = c.post(uri, json)
+	} else {
+		uri = fmt.Sprintf("%s/rest/api/2/issue/%s/watchers?username=%s", c.endpoint, issue, watcher)
+		resp, err = c.delete(uri)
+	}
 	if err != nil {
 		return err
 	}
@@ -412,7 +424,11 @@ func (c *Cli) CmdWatch(issue string) error {
 	} else {
 		logBuffer := bytes.NewBuffer(make([]byte, 0))
 		resp.Write(logBuffer)
-		err := fmt.Errorf("Unexpected Response From POST")
+		if !remove {
+			err = fmt.Errorf("Unexpected Response From POST")
+		} else {
+			err = fmt.Errorf("Unexpected Response From DELETE")
+		}
 		log.Error("%s:\n%s", err, logBuffer)
 		return err
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -57,6 +57,7 @@ Usage:
   jira DUPLICATE dups ISSUE
   jira BLOCKER blocks ISSUE
   jira watch ISSUE [-w WATCHER]
+  jira vote ISSUE [--down]
   jira (trans|transition) TRANSITION ISSUE [--noedit] <Edit Options>
   jira ack ISSUE [--edit] <Edit Options>
   jira close ISSUE [--edit] <Edit Options>
@@ -156,7 +157,6 @@ Command Options:
 		"req":              "request",
 		"request":          "request",
 		"vote":             "vote",
-		"unvote":           "unvote",
 	}
 
 	defaults := map[string]interface{}{
@@ -208,6 +208,7 @@ Command Options:
 		"M|method=s":            setopt,
 		"S|saveFile=s":          setopt,
 		"Q|quiet":               setopt,
+		"down":                  setopt,
 	})
 
 	if err := op.ProcessAll(os.Args[1:]); err != nil {
@@ -408,10 +409,11 @@ Command Options:
 		err = c.CmdView(args[0])
 	case "vote":
 		requireArgs(1)
-		err = c.CmdVote(args[0])
-	case "unvote":
-		requireArgs(1)
-		err = c.CmdUnvote(args[0])
+		if val, ok := opts["down"]; ok {
+			err = c.CmdVote(args[0], !val.(bool))
+		} else {
+			err = c.CmdVote(args[0], true)
+		}
 	case "request":
 		requireArgs(1)
 		data := ""

--- a/main/main.go
+++ b/main/main.go
@@ -56,8 +56,8 @@ Usage:
   jira create [--noedit] [-p PROJECT] <Create Options>
   jira DUPLICATE dups ISSUE
   jira BLOCKER blocks ISSUE
-  jira watch ISSUE [-w WATCHER]
   jira vote ISSUE [--down]
+  jira watch ISSUE [-w WATCHER] [--remove]
   jira (trans|transition) TRANSITION ISSUE [--noedit] <Edit Options>
   jira ack ISSUE [--edit] <Edit Options>
   jira close ISSUE [--edit] <Edit Options>
@@ -196,6 +196,7 @@ Command Options:
 		"a|assignee=s":          setopt,
 		"i|issuetype=s":         setopt,
 		"w|watcher=s":           setopt,
+		"remove":                setopt,
 		"r|reporter=s":          setopt,
 		"f|queryfields=s":       setopt,
 		"s|sort=s":              setopt,
@@ -353,7 +354,9 @@ Command Options:
 		}
 	case "watch":
 		requireArgs(1)
-		err = c.CmdWatch(args[0])
+		watcher := c.GetOptString("watcher", opts["user"].(string))
+		remove := c.GetOptBool("remove", false)
+		err = c.CmdWatch(args[0], watcher, remove)
 	case "transition":
 		requireArgs(2)
 		setEditing(true)

--- a/main/main.go
+++ b/main/main.go
@@ -151,6 +151,8 @@ Command Options:
 		"login":            "login",
 		"req":              "request",
 		"request":          "request",
+		"vote":             "vote",
+		"unvote":           "unvote",
 	}
 
 	defaults := map[string]interface{}{
@@ -392,6 +394,12 @@ Command Options:
 	case "view":
 		requireArgs(1)
 		err = c.CmdView(args[0])
+	case "vote":
+		requireArgs(1)
+		err = c.CmdVote(args[0])
+	case "unvote":
+		requireArgs(1)
+		err = c.CmdUnvote(args[0])
 	case "request":
 		requireArgs(1)
 		data := ""


### PR DESCRIPTION
As per discussion in #26 -- here is 'remove watcher' support, eg:

    jira watch EXAMPLE-123 --watcher bob --remove

I've exposed GetOptString and GetOptBool in the same manner as before - leave the private function intact, just add a public wrapper.

I've mentioned in the commit, but I've expressly not included 'remove: false' as a default option, since at the moment this is specific to 'watch' command. Maybe if we find other reasons to add '--remove' we can promote it.

NOTE: this commit involves a breaking change to the CmdWatch contract, in that it now takes the watcher and whether to remove as arguments. I think i'm the only consumer of this as a library right now, so this is likely not a big problem.