### PR TITLE
Add component/components support: add and list for now.

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -73,6 +73,8 @@ Usage:
   jira issuelinktypes
   jira transmeta ISSUE
   jira editmeta ISSUE
+  jira add component [-p PROJECT] NAME DESCRIPTION LEAD
+  jira components [-p PROJECT]
   jira issuetypes [-p PROJECT] 
   jira createmeta [-p PROJECT] [-i ISSUETYPE] 
   jira transitions ISSUE
@@ -141,6 +143,8 @@ Command Options:
 		"comment":          "comment",
 		"label":            "labels",
 		"labels":           "labels",
+		"component":        "component",
+		"components":       "components",
 		"take":             "take",
 		"assign":           "assign",
 		"give":             "assign",
@@ -395,6 +399,23 @@ Command Options:
 		issue := args[1]
 		labels := args[2:]
 		err = c.CmdLabels(action, issue, labels)
+	case "component":
+		requireArgs(2)
+		action := args[0]
+		project := opts["project"].(string)
+		name := args[1]
+		var lead string
+		var description string
+		if len(args) > 2 {
+			description = args[2]
+		}
+		if len(args) > 3 {
+			lead = args[2]
+		}
+		err = c.CmdComponent(action, project, name, description, lead)
+	case "components":
+		project := opts["project"].(string)
+		err = c.CmdComponents(project)
 	case "take":
 		requireArgs(1)
 		err = c.CmdAssign(args[0], opts["user"].(string))

--- a/templates.go
+++ b/templates.go
@@ -12,6 +12,7 @@ var all_templates = map[string]string{
 	"view":           default_view_template,
 	"edit":           default_edit_template,
 	"transitions":    default_transitions_template,
+	"components":     default_components_template,
 	"issuetypes":     default_issuetypes_template,
 	"create":         default_create_template,
 	"comment":        default_comment_template,
@@ -80,6 +81,9 @@ fields:
 # {{end}}
 `
 const default_transitions_template = `{{ range .transitions }}{{.id }}: {{.name}}
+{{end}}`
+
+const default_components_template = `{{ range . }}{{.id }}: {{.name}}
 {{end}}`
 
 const default_issuetypes_template = `{{ range .projects }}{{ range .issuetypes }}{{color "+bh"}}{{.name | append ":" | printf "%-13s" }}{{color "reset"}} {{.description}}


### PR DESCRIPTION
This adds the basics of the component API:

* listing of components assigned to a project
* adding new components to a project.

The interface to 'add component' is similar to that of 'labels', as
previously discussed. We can implement remove/update later.