### PR TITLE
Fixes #32 - make path to cookieFile if it's not present

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -87,6 +88,7 @@ func (c *Cli) saveCookies(cookies []*http.Cookie) {
 		}
 		jsonWrite(c.cookieFile, mergedCookies)
 	} else {
+		mkdir(path.Dir(c.cookieFile))
 		jsonWrite(c.cookieFile, cookies)
 	}
 }


### PR DESCRIPTION
TL;DR, this ensures ~/jira.d is present, with 0755 perms.

If `~/jira.d` isn't present, we can't write to the cookieFile, which
breaks CmdLogin. This is particularly an issue when using `/etc/go-jira.yml`
to get an entire team using go-jira easily :)

This fixes this by ensuring the cookieFile dir is present before
writing to it.