### PR TITLE
Fix issuetype calls adding URL escaping

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"strings"
 	// "github.com/kr/pretty"
@@ -181,7 +182,7 @@ func (c *Cli) CmdCreateMeta() error {
 	issuetype := c.getOptString("issuetype", "Bug")
 
 	log.Debug("createMeta called")
-	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", c.endpoint, project, issuetype)
+	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", c.endpoint, project, url.QueryEscape(issuetype))
 	data, err := responseToJson(c.get(uri))
 	if err != nil {
 		return err
@@ -227,7 +228,7 @@ func (c *Cli) CmdCreate() error {
 	issuetype := c.getOptString("issuetype", "Bug")
 	log.Debug("create called")
 
-	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", c.endpoint, project, issuetype)
+	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", c.endpoint, project, url.QueryEscape(issuetype))
 	data, err := responseToJson(c.get(uri))
 	if err != nil {
 		return err


### PR DESCRIPTION
It is valid within JIRA to have issue types with spaces (for example we use "Pro-Active Task") however the `issuetype` variable is not escaped prior to formatting into the `uri` string.

This fix imports `net/url` and escapes all inclusions of `issuetype` into `uri`. The only other variables formatted into `uri` are `c.endpoint` and `issue` which shouldn't contain special characters.