### PR TITLE
Noting jira login

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ endpoint: https://jira.mycompany.com
 EOM
 ```
 
+Then use `jira login` to authenticate yourself.
+
 ### Dynamic Configuration
 
 If the **.jira.d/config.yml** file is executable, then **go-jira** will attempt to execute the file and use the stdout for configuration.  You can use this to customize templates or other overrides depending on what type of operation you are running.  For example if you would like to use the "table" template when ever you run `jira ls`, then you can create a template like this:
@@ -193,7 +195,7 @@ General Options:
   -e --endpoint=URI   URI to use for jira
   -h --help           Show this usage
   -t --template=FILE  Template file to use for output/editing
-  -u --user=USER      Username to use for authenticaion (default: $USER)
+  -u --user=USER      Username to use for authentication (default: $USER)
   -v --verbose        Increase output logging
 
 Query Options:


### PR DESCRIPTION
For a new user, the obvious first step is to configure a server and log in, but only the first half of this was mentioned. Trying to use non-read-only commands like `watch` before that just yields an opaque error, rather than prompting you to log in (0.1.0):

```
… INFO  [cli.go:145] POST https://…/rest/api/2/issue/…/watchers
… ERROR [cli.go:198] response status: 500 Internal Server Error
… ERROR [commands.go:443] Unexpected Response From POST:
HTTP/1.1 500 Internal Server Error
Connection: close
Transfer-Encoding: chunked
Cache-Control: no-cache, no-store, no-transform
Content-Type: application/json;charset=UTF-8
Date: …
Server: Apache-Coyote/1.1
Via: 1.1 …
X-Arequestid: …
X-Asen: …
X-Asessionid: …
X-Ausername: anonymous
X-Content-Type-Options: nosniff

37
{"errorMessages":["Internal server error"],"errors":{}}
0
```

Regarding the `--user` option, I presume there is some config file key to set this permanently, though it does not seem to be documented; in my case my Linux `$USER` was in fact my JIRA username as well.

After `login`, I could `watch` on a username/password-based JIRA server. If there is a way to use SSO with atlassian.net, I could not find it. Assuming that is unsupported, it would be wise to mention this prominently.