### PR TITLE
Include templates from a system path

### DIFF
--- a/util.go
+++ b/util.go
@@ -57,6 +57,7 @@ func FindClosestParentPath(fileName string) (string, error) {
 func readFile(file string) string {
 	var bytes []byte
 	var err error
+	log.Debugf("readFile: reading %q", file)
 	if bytes, err = ioutil.ReadFile(file); err != nil {
 		log.Errorf("Failed to read file %s: %s", file, err)
 		os.Exit(1)


### PR DESCRIPTION
I've found that several of the built-in templates need a bit of work
to be useful with our JIRA installation (eg #24), so this allows for admins
to make a site-specific set of defaults easily.