### PR TITLE
Prefer transition names which match exactly

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -666,6 +666,9 @@ func (c *Cli) CmdTransition(issue string, trans string) error {
 			transName = name
 			transID = id
 			transMeta = transition.(map[string]interface{})
+			if strings.ToLower(name) == strings.ToLower(trans) {
+				break
+			}
 		}
 	}
 	if transID == "" {


### PR DESCRIPTION
Some transitions are substrings of other transitions, and the current loop sometimes doesn't choose the best match. For example, it would never choose "QA" if there were also a transition "Deploy to QA". Ditto for "Open" and "Reopen".