### PR TITLE
Add support for a unix socket proxy

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -103,7 +103,7 @@ General Options:
   -t --template=FILE  Template file to use for output/editing
   -u --user=USER      Username to use for authenticaion (default: %s)
   -v --verbose        Increase output logging
-  --unixproxy=PATH    Path for a local unix proxy (for client certificate injection)
+  --unixproxy=PATH    Path for a unix-socket proxy (eg., --unixproxy /tmp/proxy.sock)
   --version           Print version
 
 Query Options:

--- a/main/main.go
+++ b/main/main.go
@@ -103,6 +103,7 @@ General Options:
   -t --template=FILE  Template file to use for output/editing
   -u --user=USER      Username to use for authenticaion (default: %s)
   -v --verbose        Increase output logging
+  --unixproxy=PATH    Path for a local unix proxy (for client certificate injection)
   --version           Print version
 
 Query Options:
@@ -239,6 +240,7 @@ Command Options:
 		"S|saveFile=s":          setopt,
 		"T|time-spent=s":        setopt,
 		"Q|quiet":               setopt,
+		"unixproxy":             setopt,
 		"down":                  setopt,
 	})
 

--- a/unixproxy.go
+++ b/unixproxy.go
@@ -1,0 +1,41 @@
+package jira
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Transport struct {
+	shadow http.Transport
+}
+
+func NewUnixProxyTransport(path string) *Transport {
+	dial := func(network, addr string) (net.Conn, error) {
+		return net.Dial("unix", path)
+	}
+
+	shadow := http.Transport{
+		Dial:                  dial,
+		DialTLS:               dial,
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 10 * time.Second,
+	}
+
+	return &Transport{shadow}
+}
+
+func UnixProxy(path string) *Transport {
+	return NewUnixProxyTransport(os.ExpandEnv(path))
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := *req
+	url2 := *req.URL
+	req2.URL = &url2
+	req2.URL.Opaque = fmt.Sprintf("//%s%s", req.URL.Host, req.URL.EscapedPath())
+	return t.shadow.RoundTrip(&req2)
+}


### PR DESCRIPTION
Hi there!

### Summary

We use client certificate authentication, and have a running local proxy on our laptops that allows us to proxy to our internal services, such as JIRA. This is accomplished by shadowing the transport with a custom dialer. It works on my machine :sparkles:. I'm inexperienced with Go a bit, so please advise if I'm doing something absurd!

### What's this PR do?

1. Adds a unixproxy.go file which implements a transport with a shadow to use a unix socket
2. Adds a `unixproxy` configuration option to point to an path on the computer to use
3. If configured, uses the unix proxy as a transport for all http requests

Thanks!