### PR TITLE
Implement "browse" subcommand on Windows

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -451,6 +451,8 @@ func (c *Cli) Browse(issue string) error {
 			return exec.Command("open", fmt.Sprintf("%s/browse/%s", c.endpoint, issue)).Run()
 		} else if runtime.GOOS == "linux" {
 			return exec.Command("xdg-open", fmt.Sprintf("%s/browse/%s", c.endpoint, issue)).Run()
+		} else if runtime.GOOS == "windows" {
+			return exec.Command("cmd", "/c", "start", fmt.Sprintf("%s/browse/%s", c.endpoint, issue)).Run()
 		}
 	}
 	return nil


### PR DESCRIPTION
Cory, thanks a lot for your excellent tool! I found that "jira browse" did not do anything on Windows yet. I added the missing code to Browse() in cli.go. Hope the change makes sense. (I am a total Go newbie, so there is a good chance I am missing something.)