### PR TITLE
Added generic issuelink command

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -64,6 +64,7 @@ Usage:
   jira subtask ISSUE [--noedit] <Create Options>
   jira DUPLICATE dups ISSUE
   jira BLOCKER blocks ISSUE
+  jira issuelink OUTWARDISSUE ISSUELINKTYPE INWARDISSUE
   jira vote ISSUE [--down]
   jira rank ISSUE (after|before) ISSUE
   jira watch ISSUE [-w WATCHER] [--remove]
@@ -150,6 +151,7 @@ Command Options:
 		"subtask":          "subtask",
 		"dups":             "dups",
 		"blocks":           "blocks",
+		"issuelink":        "issuelink",
 		"watch":            "watch",
 		"trans":            "transition",
 		"transition":       "transition",
@@ -335,6 +337,9 @@ Command Options:
 
 	var err error
 	switch command {
+	case "issuelink":
+		requireArgs(3)
+		err = c.CmdIssueLink(args[0], args[1], args[2])
 	case "login":
 		err = c.CmdLogin()
 	case "logout":


### PR DESCRIPTION
This allows adding generic links, and could replace 'blocks', and 'dups'
command, since it's pretty much just a copy/paste job.

Usage will be something like:

`$ jira issuelink $INWARDISSUE "Relates" OUTWARDISSUE`

Pulling the list of the names, for your issuelinktypes

```
$ jira issuelinktypes | jq '.issueLinkTypes | map(.name)'
[
  "Blocks",
  "Bonfire testing",
  "Clones",
  "Deprecates",
  "Duplicate",
  "Relates",
  "Risks"
]
```