### PR TITLE
add documentation to auth with pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ Then initialize the `pass` tool to use the correct key:
 $ pass init "Go Jira <gojira@example.com>"
 ```
 
+`go-jira` expects user's password to be stored under `GoJira/<user>`:
+```
+$ pass insert GoJira/<user>
+```
+
+
 You probably want to setup gpg-agent so that you dont have to type in your gpg passphrase all the time.  You can get `gpg-agent` to automatically start by adding something like this to your `$HOME/.bashrc`
 ```bash
 if [ -f $HOME/.gpg-agent-info ]; then


### PR DESCRIPTION
Currently README.md is missing a crucial part: when I configure go-jira to use pass, which entry is it looking for? It's 'GoJira/<user>'. Documentation to create this entry was added to README.md.