### PR TITLE
Handle keyring.ErrNotFound error instead of panicing.

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -5,7 +5,11 @@ package jira
 import "github.com/tmc/keyring"
 
 func keyringGet(user string) (string, error) {
-	return keyring.Get("go-jira", user)
+	password, err := keyring.Get("go-jira", user)
+	if err != nil && err != keyring.ErrNotFound {
+	    return password, err
+	}
+	return password, nil
 }
 
 func keyringSet(user, passwd string) error {


### PR DESCRIPTION
github.com/tmc/keyring returns keyring.ErrNotFound instead of a blank password in newer libraries. Handle this case properly by nulling the error, to give the user a chance to set a new password.

This makes go-jira compatible with the newer versions which now incorporate a fix for working out-of-the-box on Linux.