### PR TITLE
Go 1.9 fixes a problem with SSL certificate discovery on Mac OS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 language: go
 go_import_path: gopkg.in/Netflix-Skunkworks/go-jira.v1
 go:
-  - 1.8
+  - 1.9
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Prior to 1.9 only the deepest level of system SSL certs were used by the Golang
SSL library, which meant that users with custom certificates would not have
them discovered (unless they edited the much lower level store). This is fixed
in Go 1.9, and thus upping the release version will fix it for all users.