### PR TITLE
Add regexReplace template function

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"reflect"
 	"strconv"
 	"strings"
@@ -130,6 +131,10 @@ func TemplateProcessor() *template.Template {
 		},
 		"color": func(color string) string {
 			return ansi.ColorCode(color)
+		},
+		"regReplace": func(search string, replace string, content string) string {
+			re := regexp.MustCompile(search)
+			return re.ReplaceAllString(content, replace)
 		},
 		"split": func(sep string, content string) []string {
 			return strings.Split(content, sep)


### PR DESCRIPTION
#### What's this PR do?
It add a regRepace function to the template functions.
#### How should this be manually tested?
Have a template like `{{ .fields.description | regReplace "foo" "bar" }}`
#### Any background context you want to provide?
Alot of out Tickets are created via email.
Jira often creates double newlines, one for \n and one for \r, also People tend to use a lot of newlines in Email.
This results in tickets, larger than one full screen terminal, containing mostly newlines.
To solve this, and have simple but powerful code i decided to implement regexReplace instead of this specific behavior.


