### PR TITLE
Add URL escaping to an additional issuetype call

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -246,7 +246,7 @@ func (j *Jira) GetIssueCreateMetaIssueType(projectKey, issueTypeName string) (*j
 }
 
 func GetIssueCreateMetaIssueType(ua HttpClient, endpoint string, projectKey, issueTypeName string) (*jiradata.IssueType, error) {
-	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", endpoint, projectKey, issueTypeName)
+	uri := fmt.Sprintf("%s/rest/api/2/issue/createmeta?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", endpoint, projectKey, url.QueryEscape(issueTypeName))
 	resp, err := ua.GetJSON(uri)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In #34 a fix was made to escape the issue type to support issue types
with spaces in. This is an additional place where the issue type needs
escaping, otherwise you get 400 Bad Request when trying to create an
issue for an issuetype that has a space in.