### PR TITLE
make it easier to compile with aribtrary version of go via GO env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NAME=jira
+GO?=go
 
 OS=$(shell uname -s)
 ifeq ($(filter CYGWIN%,$(OS)),$(OS))
@@ -20,17 +21,17 @@ CURVER ?= $(patsubst v%,%,$(shell [ -d .git ] && git describe --abbrev=0 --tags 
 LDFLAGS:= -w
 
 build:
-	go build -gcflags="-e" -v -ldflags "$(LDFLAGS) -s" -o '$(BIN)' cmd/jira/main.go
+	$(GO) build -gcflags="-e" -v -ldflags "$(LDFLAGS) -s" -o '$(BIN)' cmd/jira/main.go
 
 vet:
-	@go vet .
-	@go vet ./jiracli
-	@go vet ./jiracmd
-	@go vet ./jiradata
-	@go vet ./cmd/jira
+	@$(GO) vet .
+	@$(GO) vet ./jiracli
+	@$(GO) vet ./jiracmd
+	@$(GO) vet ./jiradata
+	@$(GO) vet ./cmd/jira
 
 lint:
-	@go get github.com/golang/lint/golint
+	@$(GO) get github.com/golang/lint/golint
 	@golint .
 	@golint ./jiracli
 	@golint ./jiracmd
@@ -38,7 +39,7 @@ lint:
 	@golint ./cmd/jira
 
 all:
-	go get -u github.com/karalabe/xgo
+	$(GO) get -u github.com/karalabe/xgo
 	rm -rf dist
 	mkdir -p dist
 	xgo --go 1.9.0 --targets="freebsd/amd64,linux/386,linux/amd64,windows/386,windows/amd64,darwin/amd64" -dest ./dist -ldflags="-w -s" ./cmd/jira


### PR DESCRIPTION
Ubuntu 16.04 has go PPAs for the latest version, but does not link them to /usr/bin/go. As a result to use any other version of go than the default requires full path to go.

Per the standards used for c and c++ this adds a $GO variable which defaults to `go` which can be passed in via env var for a specific version of go.

Example:
```
export GO=/usr/lib/go-1.9/bin/go
$ make
/usr/lib/go-1.9/bin/go build -gcflags="-e" -v -ldflags "-w -s" -o '/home/asomerville/go/src/gopkg.in/Netflix-Skunkworks/go-jira.v1/jira' cmd/jira/main.go
command-line-arguments
```

