### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang
+
+COPY . /go/src/gopkg.in/Netflix-Skunkworks/go-jira.v1
+WORKDIR /go/src/gopkg.in/Netflix-Skunkworks/go-jira.v1
+
+RUN make
+
+ENTRYPOINT [ "./jira" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Golang image, latest tag. More info at https://hub.docker.com/_/golang/.
No Golang install needed on systems with Docker, both for running or for developing/testing.

Just adding files, setting working dir and running ```make```.

Build:

```
$ docker build -t go-jira .
```

Run:

```
$ docker run --rm -it -e JIRA_API_TOKEN=xxxx -v [your_host_config_yml]:/go/src/gopkg.in/Netflix-Skunkworks/go-jira.v1/.jira.d/config.yml:ro go-jira [other options...]
```
If you're testing locally, perhaps your ```config.yml``` got baked in the previous ```docker build``` and you don't need to ```-v``` mount your host's yml config file.

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -e JIRA_API_TOKEN=xxxx -v [your_host_config_yml]:/go/src/gopkg.in/Netflix-Skunkworks/go-jira.v1/.jira.d/config.yml:ro pataquets/go-jira-src [other options...]
```

Using `--rm` causes the container to be deleted after running.