### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/jiracmd/dup.go
+++ b/jiracmd/dup.go
@@ -60,7 +60,7 @@ func CmdDupUsage(cmd *kingpin.CmdClause, opts *DupOptions) error {
 	return nil
 }
 
-// CmdDups will update the given issue as being a duplicate by the given dup issue
+// CmdDup will update the given issue as being a duplicate by the given dup issue
 // and will attempt to resolve the dup issue
 func CmdDup(o *oreo.Client, globals *jiracli.GlobalOptions, opts *DupOptions) error {
 	if err := jira.LinkIssues(o, globals.Endpoint.Value, &opts.LinkIssueRequest); err != nil {

--- a/jiracmd/editmeta.go
+++ b/jiracmd/editmeta.go
@@ -41,7 +41,7 @@ func CmdEditMetaUsage(cmd *kingpin.CmdClause, opts *EditMetaOptions) error {
 	return nil
 }
 
-// EditMeta will get issue edit metadata and send to "editmeta" template
+// CmdEditMeta will get issue edit metadata and send to "editmeta" template
 func CmdEditMeta(o *oreo.Client, globals *jiracli.GlobalOptions, opts *EditMetaOptions) error {
 	editMeta, err := jira.GetIssueEditMeta(o, globals.Endpoint.Value, opts.Issue)
 	if err != nil {

--- a/jiracmd/issuelink.go
+++ b/jiracmd/issuelink.go
@@ -54,7 +54,7 @@ func CmdIssueLinkUsage(cmd *kingpin.CmdClause, opts *IssueLinkOptions) error {
 	return nil
 }
 
-// CmdBlock will update the given issue as being a duplicate by the given dup issue
+// CmdIssueLink will update the given issue as being a duplicate by the given dup issue
 // and will attempt to resolve the dup issue
 func CmdIssueLink(o *oreo.Client, globals *jiracli.GlobalOptions, opts *IssueLinkOptions) error {
 	if err := jira.LinkIssues(o, globals.Endpoint.Value, &opts.LinkIssueRequest); err != nil {

--- a/jiracmd/labelsAdd.go
+++ b/jiracmd/labelsAdd.go
@@ -39,7 +39,7 @@ func CmdLabelsAddUsage(cmd *kingpin.CmdClause, opts *LabelsAddOptions) error {
 	return nil
 }
 
-// CmdLabels will add labels on a given issue
+// CmdLabelsAdd will add labels on a given issue
 func CmdLabelsAdd(o *oreo.Client, globals *jiracli.GlobalOptions, opts *LabelsAddOptions) error {
 	ops := jiradata.FieldOperations{}
 	for _, label := range opts.Labels {

--- a/jiracmd/labelsRemove.go
+++ b/jiracmd/labelsRemove.go
@@ -39,7 +39,7 @@ func CmdLabelsRemoveUsage(cmd *kingpin.CmdClause, opts *LabelsRemoveOptions) err
 	return nil
 }
 
-// CmdLabels will remove labels on a given issue
+// CmdLabelsRemove will remove labels on a given issue
 func CmdLabelsRemove(o *oreo.Client, globals *jiracli.GlobalOptions, opts *LabelsRemoveOptions) error {
 	ops := jiradata.FieldOperations{}
 	for _, label := range opts.Labels {

--- a/jiracmd/labelsSet.go
+++ b/jiracmd/labelsSet.go
@@ -39,7 +39,7 @@ func CmdLabelsSetUsage(cmd *kingpin.CmdClause, opts *LabelsSetOptions) error {
 	return nil
 }
 
-// CmdLabels will set labels on a given issue
+// CmdLabelsSet will set labels on a given issue
 func CmdLabelsSet(o *oreo.Client, globals *jiracli.GlobalOptions, opts *LabelsSetOptions) error {
 	issueUpdate := jiradata.IssueUpdate{
 		Update: jiradata.FieldOperationsMap{

--- a/jiracmd/worklogList.go
+++ b/jiracmd/worklogList.go
@@ -40,7 +40,7 @@ func CmdWorklogListUsage(cmd *kingpin.CmdClause, opts *WorklogListOptions) error
 	return nil
 }
 
-// // CmdWorklogList will get worklog data for given issue and sent to the "worklogs" template
+// CmdWorklogList will get worklog data for given issue and sent to the "worklogs" template
 func CmdWorklogList(o *oreo.Client, globals *jiracli.GlobalOptions, opts *WorklogListOptions) error {
 	data, err := jira.GetIssueWorklog(o, globals.Endpoint.Value, opts.Issue)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?