### PR TITLE
don't use ReadAll when decoding JSON

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -1,6 +1,8 @@
 package jira
 
 import (
+	"encoding/json"
+
 	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
 )
 
@@ -19,7 +21,7 @@ func GetAttachment(ua HttpClient, endpoint string, id string) (*jiradata.Attachm
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.Attachment{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }

--- a/component.go
+++ b/component.go
@@ -31,7 +31,7 @@ func CreateComponent(ua HttpClient, endpoint string, cp ComponentProvider) (*jir
 
 	if resp.StatusCode == 201 {
 		results := &jiradata.Component{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }

--- a/epic.go
+++ b/epic.go
@@ -53,7 +53,7 @@ func EpicSearch(ua HttpClient, endpoint string, epic string, sp SearchProvider) 
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.SearchResults{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }

--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
@@ -8,7 +9,7 @@ import (
 
 func responseError(resp *http.Response) error {
 	results := &jiradata.ErrorCollection{}
-	if err := readJSON(resp.Body, results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(results); err != nil {
 		results.Status = resp.StatusCode
 		results.ErrorMessages = append(results.ErrorMessages, err.Error())
 	}

--- a/fields.go
+++ b/fields.go
@@ -1,6 +1,8 @@
 package jira
 
 import (
+	"encoding/json"
+
 	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
 )
 
@@ -18,7 +20,7 @@ func GetFields(ua HttpClient, endpoint string) ([]jiradata.Field, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode == 200 {
 		results := []jiradata.Field{}
-		return results, readJSON(resp.Body, &results)
+		return results, json.NewDecoder(resp.Body).Decode(&results)
 	}
 	return nil, responseError(resp)
 }

--- a/issue.go
+++ b/issue.go
@@ -69,7 +69,7 @@ func GetIssue(ua HttpClient, endpoint string, issue string, iqg IssueQueryProvid
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.Issue{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -95,7 +95,7 @@ func GetIssueWorklog(ua HttpClient, endpoint string, issue string) (*jiradata.Wo
 
 		if resp.StatusCode == 200 {
 			results := &jiradata.WorklogWithPagination{}
-			err := readJSON(resp.Body, results)
+			err := json.NewDecoder(resp.Body).Decode(results)
 			if err != nil {
 				return nil, err
 			}
@@ -133,7 +133,7 @@ func AddIssueWorklog(ua HttpClient, endpoint string, issue string, wp WorklogPro
 
 	if resp.StatusCode == 201 {
 		results := &jiradata.Worklog{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -153,7 +153,7 @@ func GetIssueEditMeta(ua HttpClient, endpoint string, issue string) (*jiradata.E
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.EditMeta{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -206,7 +206,7 @@ func CreateIssue(ua HttpClient, endpoint string, iup IssueUpdateProvider) (*jira
 
 	if resp.StatusCode == 201 {
 		results := &jiradata.IssueCreateResponse{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -227,7 +227,7 @@ func GetIssueCreateMetaProject(ua HttpClient, endpoint string, projectKey string
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.CreateMeta{}
-		err = readJSON(resp.Body, results)
+		err = json.NewDecoder(resp.Body).Decode(results)
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +257,7 @@ func GetIssueCreateMetaIssueType(ua HttpClient, endpoint string, projectKey, iss
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.CreateMeta{}
-		err = readJSON(resp.Body, results)
+		err = json.NewDecoder(resp.Body).Decode(results)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func GetIssueTransitions(ua HttpClient, endpoint string, issue string) (*jiradat
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.TransitionsMeta{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -367,7 +367,7 @@ func GetIssueLinkTypes(ua HttpClient, endpoint string) (*jiradata.IssueLinkTypes
 		}{
 			IssueLinkTypes: jiradata.IssueLinkTypes{},
 		}
-		return &results.IssueLinkTypes, readJSON(resp.Body, &results)
+		return &results.IssueLinkTypes, json.NewDecoder(resp.Body).Decode(&results)
 	}
 	return nil, responseError(resp)
 }
@@ -501,7 +501,7 @@ func IssueAddComment(ua HttpClient, endpoint string, issue string, cp CommentPro
 
 	if resp.StatusCode == 201 {
 		results := jiradata.Comment{}
-		return &results, readJSON(resp.Body, &results)
+		return &results, json.NewDecoder(resp.Body).Decode(&results)
 	}
 	return nil, responseError(resp)
 }
@@ -579,7 +579,7 @@ func IssueAttachFile(ua HttpClient, endpoint string, issue, filename string, con
 
 	if resp.StatusCode == 200 {
 		results := jiradata.ListOfAttachment{}
-		return &results, readJSON(resp.Body, &results)
+		return &results, json.NewDecoder(resp.Body).Decode(&results)
 	}
 	return nil, responseError(resp)
 }

--- a/jiracmd/request.go
+++ b/jiracmd/request.go
@@ -3,7 +3,6 @@ package jiracmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -75,21 +74,9 @@ func CmdRequest(o *oreo.Client, globals *jiracli.GlobalOptions, opts *RequestOpt
 	}
 	defer resp.Body.Close()
 
-	content, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if len(content) == 0 {
-		if !globals.Quiet.Value {
-			fmt.Println("No content in response")
-		}
-		return nil
-	}
 	var data interface{}
-	err = json.Unmarshal(content, &data)
-	if err != nil {
-		return fmt.Errorf("JSON Parse Error: %s from %q", err, content)
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return fmt.Errorf("JSON Parse Error: %v", err)
 	}
-
 	return opts.PrintTemplate(&data)
 }

--- a/project.go
+++ b/project.go
@@ -1,6 +1,8 @@
 package jira
 
 import (
+	"encoding/json"
+
 	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
 )
 
@@ -19,7 +21,7 @@ func GetProjectComponents(ua HttpClient, endpoint string, project string) (*jira
 
 	if resp.StatusCode == 200 {
 		results := jiradata.Components{}
-		return &results, readJSON(resp.Body, &results)
+		return &results, json.NewDecoder(resp.Body).Decode(&results)
 	}
 	return nil, responseError(resp)
 }

--- a/search.go
+++ b/search.go
@@ -120,7 +120,7 @@ func Search(ua HttpClient, endpoint string, sp SearchProvider, opts ...SearchOpt
 		}
 
 		page := &jiradata.SearchResults{}
-		err = readJSON(resp.Body, page)
+		err = json.NewDecoder(resp.Body).Decode(page)
 		if err != nil {
 			return nil, err
 		}

--- a/session.go
+++ b/session.go
@@ -43,7 +43,7 @@ func NewSession(ua HttpClient, endpoint string, ap AuthProvider) (*jiradata.Auth
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.AuthSuccess{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }
@@ -63,7 +63,7 @@ func GetSession(ua HttpClient, endpoint string) (*jiradata.CurrentUser, error) {
 
 	if resp.StatusCode == 200 {
 		results := &jiradata.CurrentUser{}
-		return results, readJSON(resp.Body, results)
+		return results, json.NewDecoder(resp.Body).Decode(results)
 	}
 	return nil, responseError(resp)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,28 +1,10 @@
 package jira
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/url"
 	"path"
 )
-
-func readJSON(input io.Reader, data interface{}) error {
-	content, err := ioutil.ReadAll(input)
-	if err != nil {
-		return err
-	}
-	if len(content) == 0 {
-		return nil
-	}
-	err = json.Unmarshal(content, data)
-	if err != nil {
-		return fmt.Errorf("JSON Parse Error: %s from %q", err, content)
-	}
-	return nil
-}
 
 func URLJoin(endpoint string, paths ...string) string {
 	u, err := url.Parse(endpoint)


### PR DESCRIPTION
An empty stream isn't valid JSON, so we shouldn't silently ignore it.